### PR TITLE
feat: 장바구니용 예금 정보 조회

### DIFF
--- a/order/urls.py
+++ b/order/urls.py
@@ -21,5 +21,6 @@ urlpatterns = [
     path("menus/", MenuListView.as_view()),
     path("booth/total_revenues/", TotalRevenueView.as_view()),
     path('manager/tables/orders/', TableOrderGroupView.as_view(), name='table-order-group'),
-    path("booths/<int:booth_id>/menus/", PublicMenuListView.as_view(), name="public-menu-list"),
+    path('booths/<int:booth_id>/menus/", PublicMenuListView.as_view(), name="public-menu-list'),
+    path('cart/payment-info/', CartPaymentInfoView.as_view()),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/order/views.py
+++ b/order/views.py
@@ -841,6 +841,59 @@ class PublicMenuListView(APIView):
                 ]
             }
         }, status=200)
+        
+class CartPaymentInfoView(APIView):
+    def get(self, request):
+        booth_id = request.headers.get("X-Booth-Id")
+        table_num = request.headers.get("X-Table-Number")
+
+        if not booth_id or not table_num:
+            return Response({
+                "status": "fail",
+                "message": "헤더에 booth_id 또는 table_num이 누락되었습니다.",
+                "code": 400
+            }, status=400)
+
+        try:
+            booth = Booth.objects.get(id=booth_id)
+            table = Table.objects.get(booth_id=booth, table_num=table_num)
+        except (Booth.DoesNotExist, Table.DoesNotExist):
+            return Response({
+                "status": "fail",
+                "message": "해당 부스 또는 테이블이 존재하지 않습니다.",
+                "code": 404
+            }, status=404)
+
+        # 진행 중인 cart 조회
+        cart = Cart.objects.filter(table_id=table, cart_status=False).order_by('-id').first()
+        if not cart:
+            return Response({
+                "status": "fail",
+                "message": "진행 중인 장바구니가 없습니다.",
+                "code": 404
+            }, status=404)
+
+        try:
+            manager = Manager.objects.get(booth=booth)
+        except Manager.DoesNotExist:
+            return Response({
+                "status": "fail",
+                "message": "해당 부스의 매니저 정보가 없습니다.",
+                "code": 404
+            }, status=404)
+
+        return Response({
+            "status": "success",
+            "message": "결제 정보 조회 성공",
+            "code": 200,
+            "data": {
+                "depositor": manager.depositor,
+                "bank": manager.bank,
+                "account": manager.account,
+                "total_price": cart.total_price
+            }
+        }, status=200)
+
 
 
 # class OrderFixView(APIView):


### PR DESCRIPTION
## 🔍 What is the PR?

- 장바구니 주문 시 필요한 결제 계좌 정보를 반환하는 API 구현 (CartPaymentInfoView)
- 헤더에서 booth_id, table_num을 받아 해당 테이블의 진행 중인 주문 정보를 조회
- Manager 모델에서 예금주, 계좌번호, 은행명 반환
- 총 결제 금액 포함 응답

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

- #112 